### PR TITLE
Improve preview activity behaviour.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -123,6 +123,7 @@
             android:name=".ui.activities.preview.AudioPreviewActivity"
             android:launchMode="singleTask"
             android:excludeFromRecents="true"
+            android:taskAffinity=""
             android:theme="@style/Theme.AudioPreview">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/src/com/cyanogenmod/eleven/ui/activities/preview/AudioPreviewActivity.java
+++ b/src/com/cyanogenmod/eleven/ui/activities/preview/AudioPreviewActivity.java
@@ -474,7 +474,7 @@ public class AudioPreviewActivity extends Activity implements MediaPlayer.OnComp
     public void onCompletion(MediaPlayer mp) {
         mHandler.removeMessages(UiHandler.MSG_UPDATE_PROGRESS);
         if (mSeekBar != null && mPreviewPlayer != null) {
-            mSeekBar.setProgress(mPreviewPlayer.getCurrentPosition());
+            mSeekBar.setProgress(mPreviewPlayer.getDuration());
         }
         sendStateChange(State.PREPARED);
     }


### PR DESCRIPTION
Move the seek bar to the very end on completion, and make sure the
preview activity isn't added to the (main) player task.

Change-Id: Ic55e2b04b4be4172a7dcca45ff5f30e54c9e5d23